### PR TITLE
Change formatTime function in DateUtils.java

### DIFF
--- a/project/app/src/main/java/com/achep/base/utils/DateUtils.java
+++ b/project/app/src/main/java/com/achep/base/utils/DateUtils.java
@@ -41,7 +41,7 @@ public class DateUtils {
             if (h == 0) h = 12;
             else if (h >= 13) h -= 12;
         }
-        return h + ":" + (m < 10 ? "0" + m : m);
+        return String.format("%02d:%02d", h, m);
     }
 
 }


### PR DESCRIPTION
Change `formatTime` function in `DateUtils.java` to add leading zeros for hours of a 24 hour formatted time since Android does the same for 24 hour times for the status bar and notification drawer. The proposed code was changed to use Java's `String.format` function instead of the custom formatting.

This is a duplicate of #122 since I have accidently deleted the forked repository and I am new to git and pull request. I still have to figure things out.