### PR TITLE
Travis CI fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
     - ACDISPLAY_USE_TEST_KEY=true
 
+dist: trusty
+
+
 android:
   components:
     - platform-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 
   # Run emulator
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
-  - emulator -avd test -no-skin -no-audio -no-window &
+  - emulator -avd test -no-skin -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 sudo: false
 cache: false
-jdk: oraclejdk7
+jdk: openjdk
 env:
   global:
     - ANDROID_TARGET=android-23  

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.2
+    - build-tools-25.0.0
     - android-23
     # Extras
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 sudo: false
 cache: false
-jdk: openjdk
+jdk: openjdk8
 env:
   global:
     - ANDROID_TARGET=android-23  

--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -187,7 +187,8 @@ dependencies {
 
     // Testing-only dependencies
     //noinspection GradleDynamicVersion
-    androidTestCompile 'com.android.support:support-annotations:24.+'
+    
+    androidTestCompile 'com.android.support:support-annotations:24.2.1'
     androidTestCompile 'com.android.support.test:runner:0.4'
     androidTestCompile 'com.android.support.test:rules:0.4'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'


### PR DESCRIPTION
Fixing the CI build in Travis CI by doing the following:

using the same build tools as the Gradle file at  app level.
chaging the jdk from oraclejdk7 to openjdk8 (most modern)
Fixing a flag that's no longer available when starting the emulator -no-audio flag

